### PR TITLE
Making Published Year and IMDB ID optional when grabbing movies

### DIFF
--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -3,9 +3,9 @@ import { ListScraper } from './list';
 export interface LetterboxdMovie {
     id: number;
     name: string;
-    imdbId: string;
+    imdbId?: string|null;
     tmdbId?: string|null;
-    publishedYear: number;
+    publishedYear?: number|null;
     slug: string;
 }
 

--- a/src/scraper/movie.ts
+++ b/src/scraper/movie.ts
@@ -60,15 +60,17 @@ function extractTmdbId($: cheerio.CheerioAPI): string|null {
     return tmdbMatch[1];
 }
 
-function extractImdbId($: cheerio.CheerioAPI): string {
+function extractImdbId($: cheerio.CheerioAPI): string|null {
     const imdbLink = $('a[href*="imdb.com"]').attr('href');
     if (!imdbLink) {
-        throw new Error('Could not find IMDB link');
+        logger.debug('Could not find IMDB link. This could happen if there is a TV show in the list or the movie lacks IMDB data.');
+        return null;
     }
     
     const imdbMatch = imdbLink.match(/\/title\/(tt\d+)/);
     if (!imdbMatch) {
-        throw new Error('Could not extract IMDB ID from link');
+        logger.debug('Could not extract IMDB ID from link. This could happen because of an unexpected IMDB URL format.');
+        return null;
     }
     
     return imdbMatch[1];
@@ -83,7 +85,7 @@ function extractLetterboxdId($: cheerio.CheerioAPI): number {
     return parseInt(filmId, 10);
 }
 
-function extractPublishedYear($: cheerio.CheerioAPI): number {
+function extractPublishedYear($: cheerio.CheerioAPI): number|null {
     const releaseDateLink = $('span.releasedate a').attr('href');
     if (releaseDateLink) {
         const yearMatch = releaseDateLink.match(/\/(\d{4})\//);
@@ -92,5 +94,6 @@ function extractPublishedYear($: cheerio.CheerioAPI): number {
         }
     }
     
-    throw new Error('Could not extract published year');
+    logger.debug('Could not extract published year. This could happen if the release date format is unexpected or missing.');
+    return null;
 }


### PR DESCRIPTION
## Summary
Makes `imdbId` and `publishedYear` fields optional in the `LetterboxdMovie` interface, matching the existing pattern used for `tmdbId`. This improves scraper robustness when dealing with incomplete movie data.

## Changes
- Updated `LetterboxdMovie` interface to make `imdbId` and `publishedYear` optional (`string|null` and `number|null` respectively)
- Modified `extractImdbId()` to return `null` instead of throwing errors when IMDB data is missing
- Modified `extractPublishedYear()` to return `null` instead of throwing errors when release year is missing
- Updated error logging to use `logger.debug()` with descriptive messages explaining why extraction might fail
 
## Motivation
- Letterboxd pages sometimes contain TV shows mixed with movies, which may lack IMDB IDs or have different URL patterns
- Some movies may have missing or incomplete metadata
- Previously, missing IMDB ID or release year would cause the entire scraping process to fail
- This change allows the scraper to continue processing other movies even when some have incomplete data