### PR TITLE
Use setInterval scheduling instead of node-scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "bluebird": "^3.7.2",
     "cheerio": "^1.1.0",
     "dotenv": "^17.2.0",
-    "node-schedule": "^2.1.1",
     "nodemon": "^3.1.10",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",
@@ -34,7 +33,6 @@
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.15",
-    "@types/node-schedule": "^2.1.8",
     "express": "^5.1.0",
     "jest": "^30.0.4",
     "ts-jest": "^29.4.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,23 @@
 require('dotenv').config();
 
 
-import schedule from 'node-schedule';
 import env from './util/env';
 import logger from './util/logger';
 import { fetchMoviesFromUrl } from './scraper';
 import { upsertMovies } from './api/radarr';
 
 function startScheduledMonitoring(): void {
-  const rule = new schedule.RecurrenceRule();
-  rule.minute = env.CHECK_INTERVAL_MINUTES;
+  const intervalMs = env.CHECK_INTERVAL_MINUTES * 60 * 1000;
 
+  logger.info(`Starting scheduled monitoring. Will check every ${env.CHECK_INTERVAL_MINUTES} minutes.`);
+
+  // Run immediately on startup
   run();
 
-  schedule.scheduleJob(rule, async () => {
+  // Then run on interval
+  setInterval(async () => {
     await run();
-  });
+  }, intervalMs);
 }
 
 async function run() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,13 +763,6 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"
   integrity sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==
 
-"@types/node-schedule@^2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@types/node-schedule/-/node-schedule-2.1.8.tgz#138e73c9301335d044f33015d1342a602d849ae4"
-  integrity sha512-k00g6Yj/oUg/CDC+MeLHUzu0+OFxWbIqrFfDiLi6OPKxTujvpv29mHGM8GtKr7B+9Vv92FcK/8mRqi1DK5f3hA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*", "@types/node@^24.0.15":
   version "24.0.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-24.0.15.tgz#f34fbc973e7d64217106e0c59ed8761e6b51381e"
@@ -1356,13 +1349,6 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
-
-cron-parser@^4.2.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-4.9.0.tgz#0340694af3e46a0894978c6f52a6dbb5c0f11ad5"
-  integrity sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==
-  dependencies:
-    luxon "^3.2.1"
 
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -2495,11 +2481,6 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
-long-timeout@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/long-timeout/-/long-timeout-0.1.1.tgz#9721d788b47e0bcb5a24c2e2bee1a0da55dab514"
-  integrity sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==
-
 lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
@@ -2511,11 +2492,6 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
-
-luxon@^3.2.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.7.1.tgz#9bd09aa84a56afb00c57ea78a8ec5bd16eb24ec0"
-  integrity sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==
 
 make-dir@^4.0.0:
   version "4.0.0"
@@ -2653,15 +2629,6 @@ node-releases@^2.0.19:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
   integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
-
-node-schedule@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/node-schedule/-/node-schedule-2.1.1.tgz#6958b2c5af8834954f69bb0a7a97c62b97185de3"
-  integrity sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==
-  dependencies:
-    cron-parser "^4.2.0"
-    long-timeout "0.1.1"
-    sorted-array-functions "^1.3.0"
 
 nodemon@^3.1.10:
   version "3.1.10"
@@ -3159,11 +3126,6 @@ sonic-boom@^4.0.1:
   integrity sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==
   dependencies:
     atomic-sleep "^1.0.0"
-
-sorted-array-functions@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz#8605695563294dffb2c9796d602bd8459f7a0dd5"
-  integrity sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==
 
 source-map-support@0.5.13:
   version "0.5.13"


### PR DESCRIPTION
  ## Problem

  The previous implementation used `node-schedule` for periodic monitoring, but `node-schedule` uses cron-based scheduling with a `RecurrenceRule`. When setting `rule.minute = CHECK_INTERVAL_MINUTES`, this was incorrectly interpreted as "run at this minute of the hour" rather than "run every N minutes."

  For example, when configured with `CHECK_INTERVAL_MINUTES=120` (as in the Criterion Collection example):
  ```yaml
  lettarrboxd-criterion:
    image: ryanpage/lettarrboxd:latest
    container_name: lettarrboxd-criterion
    environment:
      - CHECK_INTERVAL_MINUTES=120
      - ...
    restart: unless-stopped
```

  The application would run once on startup and then exit with code `0`, because `node-schedule`'s `RecurrenceRule.minute` expects values 0-59 (which minute of the hour), not an arbitrary interval in minutes. Notably this section from the module description points out the problem:
  > Node Schedule is for time-based scheduling, not interval-based scheduling.

This PR removes the `node-schedule` and `@types/node-schedule` dependencies and replaces the cron-based scheduling with `setInterval` in `src/index.ts`. The tests were updated to use `jest.useFakeTimers()` instead of mocking `node-schedule`, which reduced test complexity and improved reliability.

Note: a lot of this is AI generated but seems correct and also I have the patched image running in my server and it works much better (i.e. does not restart-loop when configured to run every 2 hours)
